### PR TITLE
Fix (#22) : Redis config could not be set in the options

### DIFF
--- a/src/cache/redis-cache.js
+++ b/src/cache/redis-cache.js
@@ -14,11 +14,11 @@ class RedisCache {
     port: number,
     keyPrefix: string
   }) {
-    const options = Object.assign({}, opts || {}, {
+    const options = Object.assign({
       host: '127.0.0.1',
       port: 6379,
       keyPrefix: 'kindredAPI-'
-    })
+    }, opts || {});
 
     this.client = redis.createClient(options.port, options.host)
     this.client.on('error', function (err) {

--- a/src/cache/redis-cache.js
+++ b/src/cache/redis-cache.js
@@ -18,7 +18,7 @@ class RedisCache {
       host: '127.0.0.1',
       port: 6379,
       keyPrefix: 'kindredAPI-'
-    }, opts || {});
+    }, opts || {})
 
     this.client = redis.createClient(options.port, options.host)
     this.client.on('error', function (err) {


### PR DESCRIPTION
This PR solves the problem of the issue https://github.com/ChauTNguyen/kindred-api/issues/22.