### PR TITLE
Adding DDragon typing

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,11 +34,13 @@
     "esdoc-standard-plugin": "^1.0.0",
     "find-in-files": "^0.4.0",
     "istanbul": "^0.4.5",
+    "lint": "^0.7.0",
     "mocha": "^4.0.1",
     "prettier": "^1.10.2",
     "rimraf": "^2.6.2",
     "svg-to-png": "^4.0.0",
-    "sw2dts": "^2.5.0"
+    "sw2dts": "^2.5.0",
+    "yarn": "^1.17.3"
   },
   "dependencies": {
     "debug": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.9.11",
   "main": "index.js",
   "scripts": {
+    "postinstall": "npm run build",
     "example": "yarn lint-example; yarn build && babel ./example.js -o ./example.babel.js && node example.babel.js",
     "build": "rimraf dist/ && babel ./ --out-dir dist/ --ignore ./node_modules,./.babelrc,./package.json,./npm-debug.log --copy-files",
     "lint-src": "prettier --no-semi --single-quote --list-different --trailing-comma all --tab-width 4 --write \"./lib/**/*.js\"",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.9.11",
   "main": "index.js",
   "scripts": {
-    "postinstall": "npm run build",
     "example": "yarn lint-example; yarn build && babel ./example.js -o ./example.babel.js && node example.babel.js",
     "build": "rimraf dist/ && babel ./ --out-dir dist/ --ignore ./node_modules,./.babelrc,./package.json,./npm-debug.log --copy-files",
     "lint-src": "prettier --no-semi --single-quote --list-different --trailing-comma all --tab-width 4 --write \"./lib/**/*.js\"",

--- a/typings/dtos.ts
+++ b/typings/dtos.ts
@@ -1231,10 +1231,10 @@ interface DDragonWrapper {
     version: string
 }
 interface DDragonDataWrapper<T> extends DDragonWrapper {
-    data: {[key:string]: T}
+    data: { [key: string]: T }
 }
 export interface DDragonImageDTO {
-    id?: number; // Only really used for the ProfileIcon. Should we create an entire interface just for that or leave it here as an optional?
+    id?: number // Only really used for the ProfileIcon. Should we create an entire interface just for that or leave it here as an optional?
     full: string
     sprite: string
     group: string
@@ -1271,7 +1271,8 @@ export interface DDragonChampionStatsDTO {
     attackspeedperlevel: number
     attackspeed: number
 }
-export interface DDragonChampionListDTO extends DDragonDataWrapper<DDragonChampionListDataDTO>{ }
+export interface DDragonChampionListDTO
+    extends DDragonDataWrapper<DDragonChampionListDataDTO> {}
 export interface DDragonChampionListDataDTO {
     version: string
     id: string
@@ -1285,7 +1286,8 @@ export interface DDragonChampionListDataDTO {
     partype: string
     stats: DDragonChampionStatsDTO
 }
-export interface DDragonChampionDTO extends DDragonDataWrapper<DDragonChampionDataDTO> { }
+export interface DDragonChampionDTO
+    extends DDragonDataWrapper<DDragonChampionDataDTO> {}
 interface DDragonSpellWrapper {
     id: string
     name: string
@@ -1375,7 +1377,8 @@ export interface DDragonChampionDataDTO {
         }[]
     }[]
 }
-export interface DDragonItemWrapperDTO extends DDragonDataWrapper<DDragonItemDTO> {
+export interface DDragonItemWrapperDTO
+    extends DDragonDataWrapper<DDragonItemDTO> {
     basic: DDragonItemDTO
     groups: {
         id: string
@@ -1483,23 +1486,23 @@ export interface DDragonItemDTO {
         PercentSpellVampMod?: number
     }
     tags: string[]
-    maps: {[key:string]: boolean}
-    effect?: {[key:string]: string}
+    maps: { [key: string]: boolean }
+    effect?: { [key: string]: string }
 }
 export interface DDragonLanguageStringDTO extends DDragonDataWrapper<string> {
     tree: {
         searchKeyIgnore: string
         searchKeyRemap: string
     }
-
 }
-export interface DDragonMapDTO extends DDragonDataWrapper<DDragonMapDataDTO> { }
+export interface DDragonMapDTO extends DDragonDataWrapper<DDragonMapDataDTO> {}
 export interface DDragonMapDataDTO {
     MapName: string
     MapId: string
     image: DDragonImageDTO
 }
-export interface DDragonProfileIconDTO extends DDragonDataWrapper<DDragonImageDTO> { }
+export interface DDragonProfileIconDTO
+    extends DDragonDataWrapper<DDragonImageDTO> {}
 export interface DDragonRealmsDTO {
     n: {
         item: string
@@ -1521,7 +1524,8 @@ export interface DDragonRealmsDTO {
     profileiconmax: number
     store: null // This is just null on every server I checked. Always exists, but always null.
 }
-export interface DDragonSummonerSpellDTO extends DDragonDataWrapper<DDragonSummonerSpellDataDTO> { }
+export interface DDragonSummonerSpellDTO
+    extends DDragonDataWrapper<DDragonSummonerSpellDataDTO> {}
 export interface DDragonSummonerSpellDataDTO extends DDragonSpellWrapper {
     costBurn: string
     key: string

--- a/typings/dtos.ts
+++ b/typings/dtos.ts
@@ -163,11 +163,11 @@ export interface LolStatusV3Translation {
     content?: string
     heading?: string
 }
-export interface MatchV4MasteryDto {
+export interface MatchV4MasteryDTO {
     masteryId?: number // int32
     rank?: number // int32
 }
-export interface MatchV4MatchDto {
+export interface MatchV4MatchDTO {
     /**
      * Please refer to the Game Constants documentation.
      */
@@ -180,7 +180,7 @@ export interface MatchV4MatchDto {
     /**
      * Participant identity information.
      */
-    participantIdentities?: MatchV4ParticipantIdentityDto[]
+    participantIdentities?: MatchV4ParticipantIdentityDTO[]
     /**
      * The major.minor version typically indicates the patch the match was played on.
      */
@@ -204,11 +204,11 @@ export interface MatchV4MatchDto {
     /**
      * Team information.
      */
-    teams?: MatchV4TeamStatsDto[]
+    teams?: MatchV4TeamStatsDTO[]
     /**
      * Participant information.
      */
-    participants?: MatchV4ParticipantDto[]
+    participants?: MatchV4ParticipantDTO[]
     /**
      * Match duration in seconds.
      */
@@ -218,7 +218,7 @@ export interface MatchV4MatchDto {
      */
     gameCreation?: number // int64
 }
-export interface MatchV4MatchEventDto {
+export interface MatchV4MatchEventDTO {
     eventType?: string
     towerType?: string
     teamId?: number // int32
@@ -256,17 +256,17 @@ export interface MatchV4MatchEventDto {
     participantId?: number // int32
     buildingType?: string
     creatorId?: number // int32
-    position?: MatchV4MatchPositionDto
+    position?: MatchV4MatchPositionDTO
     beforeId?: number // int32
 }
-export interface MatchV4MatchFrameDto {
+export interface MatchV4MatchFrameDTO {
     timestamp?: number // int64
     participantFrames?: {
-        [name: string]: MatchV4MatchParticipantFrameDto
+        [name: string]: MatchV4MatchParticipantFrameDTO
     }
-    events?: MatchV4MatchEventDto[]
+    events?: MatchV4MatchEventDTO[]
 }
-export interface MatchV4MatchParticipantFrameDto {
+export interface MatchV4MatchParticipantFrameDTO {
     totalGold?: number // int32
     teamScore?: number // int32
     participantId?: number // int32
@@ -274,15 +274,15 @@ export interface MatchV4MatchParticipantFrameDto {
     currentGold?: number // int32
     minionsKilled?: number // int32
     dominionScore?: number // int32
-    position?: MatchV4MatchPositionDto
+    position?: MatchV4MatchPositionDTO
     xp?: number // int32
     jungleMinionsKilled?: number // int32
 }
-export interface MatchV4MatchPositionDto {
+export interface MatchV4MatchPositionDTO {
     y?: number // int32
     x?: number // int32
 }
-export interface MatchV4MatchReferenceDto {
+export interface MatchV4MatchReferenceDTO {
     lane?: string
     gameId?: number // int64
     champion?: number // int32
@@ -292,30 +292,30 @@ export interface MatchV4MatchReferenceDto {
     role?: string
     timestamp?: number // int64
 }
-export interface MatchV4MatchTimelineDto {
-    frames?: MatchV4MatchFrameDto[]
+export interface MatchV4MatchTimelineDTO {
+    frames?: MatchV4MatchFrameDTO[]
     frameInterval?: number // int64
 }
-export interface MatchV4MatchlistDto {
-    matches?: MatchV4MatchReferenceDto[]
+export interface MatchV4MatchlistDTO {
+    matches?: MatchV4MatchReferenceDTO[]
     totalGames?: number // int32
     startIndex?: number // int32
     endIndex?: number // int32
 }
-export interface MatchV4ParticipantDto {
+export interface MatchV4ParticipantDTO {
     /**
      * Participant statistics.
      */
-    stats?: MatchV4ParticipantStatsDto
+    stats?: MatchV4ParticipantStatsDTO
     participantId?: number // int32
     /**
      * List of legacy Rune information. Not included for matches played with Runes Reforged.
      */
-    runes?: MatchV4RuneDto[]
+    runes?: MatchV4RuneDTO[]
     /**
      * Participant timeline data.
      */
-    timeline?: MatchV4ParticipantTimelineDto
+    timeline?: MatchV4ParticipantTimelineDTO
     /**
      * 100 for blue side. 200 for red side.
      */
@@ -327,7 +327,7 @@ export interface MatchV4ParticipantDto {
     /**
      * List of legacy Mastery information. Not included for matches played with Runes Reforged.
      */
-    masteries?: MatchV4MasteryDto[]
+    masteries?: MatchV4MasteryDTO[]
     /**
      * Highest ranked tier achieved for the previous season in a specific subset of queueIds, if any, otherwise null. Used to display border in game loading screen. Please refer to the Ranked Info documentation.
      *              (Legal values:  CHALLENGER,  MASTER,  DIAMOND,  PLATINUM,  GOLD,  SILVER,  BRONZE,  UNRANKED)
@@ -347,14 +347,14 @@ export interface MatchV4ParticipantDto {
     spell1Id?: number // int32
     championId?: number // int32
 }
-export interface MatchV4ParticipantIdentityDto {
+export interface MatchV4ParticipantIdentityDTO {
     /**
      * Player information.
      */
-    player?: MatchV4PlayerDto
+    player?: MatchV4PlayerDTO
     participantId?: number // int32
 }
-export interface MatchV4ParticipantStatsDto {
+export interface MatchV4ParticipantStatsDTO {
     firstBloodAssist?: boolean
     visionScore?: number // int64
     magicDamageDealtToChampions?: number // int64
@@ -542,7 +542,7 @@ export interface MatchV4ParticipantStatsDto {
     totalMinionsKilled?: number // int32
     timeCCingOthers?: number // int64
 }
-export interface MatchV4ParticipantTimelineDto {
+export interface MatchV4ParticipantTimelineDTO {
     /**
      * Participant's calculated lane. MID and BOT are legacy values.
      *              (Legal values:  MID,  MIDDLE,  TOP,  JUNGLE,  BOT,  BOTTOM)
@@ -597,7 +597,7 @@ export interface MatchV4ParticipantTimelineDto {
         [name: string]: number // double
     }
 }
-export interface MatchV4PlayerDto {
+export interface MatchV4PlayerDTO {
     currentPlatformId?: string
     summonerName?: string
     matchHistoryUri?: string
@@ -619,11 +619,11 @@ export interface MatchV4PlayerDto {
      */
     accountId?: string
 }
-export interface MatchV4RuneDto {
+export interface MatchV4RuneDTO {
     runeId?: number // int32
     rank?: number // int32
 }
-export interface MatchV4TeamBansDto {
+export interface MatchV4TeamBansDTO {
     /**
      * Turn during which the champion was banned.
      */
@@ -633,7 +633,7 @@ export interface MatchV4TeamBansDto {
      */
     championId?: number // int32
 }
-export interface MatchV4TeamStatsDto {
+export interface MatchV4TeamStatsDTO {
     /**
      * Flag indicating whether or not the team scored the first Dragon kill.
      */
@@ -645,7 +645,7 @@ export interface MatchV4TeamStatsDto {
     /**
      * If match queueId has a draft, contains banned champion data, otherwise empty.
      */
-    bans?: MatchV4TeamBansDto[]
+    bans?: MatchV4TeamBansDTO[]
     /**
      * Number of times the team killed Baron.
      */
@@ -1203,4 +1203,328 @@ export interface TournamentV4TournamentRegistrationParameters {
      * The optional name of the tournament.
      */
     name?: string
+}
+export interface DDragonRunesReforgedDTO {
+    runeStyles: DDragonRunesReforgedRuneStyleDTO[]
+}
+export interface DDragonRunesReforgedRuneStyleDTO {
+    id: number
+    key: string
+    icon: string
+    name: string
+    slots: DDragonRunesReforgedSlotDTO[]
+}
+export interface DDragonRunesReforgedSlotDTO {
+    runes: DDragonRunesReforgedRuneDTO[]
+}
+export interface DDragonRunesReforgedRuneDTO {
+    id: number
+    key: string
+    icon: string
+    name: string
+    shortDesc: string
+    longDesc: string
+}
+interface DDragonWrapper {
+    type: string
+    format?: string
+    version: string
+}
+interface DDragonDataWrapper<T> extends DDragonWrapper {
+    data: {[key:string]: T}
+}
+export interface DDragonImageDTO {
+    id?: number; // Only really used for the ProfileIcon. Should we create an entire interface just for that or leave it here as an optional?
+    full: string
+    sprite: string
+    group: string
+    x: number
+    y: number
+    w: number
+    h: number
+}
+export interface DDragonChampionInfoDTO {
+    attack: number
+    defense: number
+    magic: number
+    difficulty: number
+}
+export interface DDragonChampionStatsDTO {
+    hp: number
+    hpperlevel: number
+    mp: number
+    mpperlevel: number
+    movespeed: number
+    armor: number
+    armorperlevel: number
+    spellblock: number
+    spellblockperlevel: number
+    attackrange: number
+    hpregen: number
+    hpregenperlevel: number
+    mpregen: number
+    mpregenperlevel: number
+    crit: number
+    critperlevel: number
+    attackdamage: number
+    attackdamageperlevel: number
+    attackspeedperlevel: number
+    attackspeed: number
+}
+export interface DDragonChampionListDTO extends DDragonDataWrapper<DDragonChampionListDataDTO>{ }
+export interface DDragonChampionListDataDTO {
+    version: string
+    id: string
+    key: string
+    name: string
+    title: string
+    blurb: string
+    info: DDragonChampionInfoDTO
+    image: DDragonImageDTO
+    tags: string[]
+    partype: string
+    stats: DDragonChampionStatsDTO
+}
+export interface DDragonChampionDTO extends DDragonDataWrapper<DDragonChampionDataDTO> { }
+interface DDragonSpellWrapper {
+    id: string
+    name: string
+    description: string
+    tooltip: string
+    maxrank: number
+    cooldown: number[]
+    cooldownBurn: string
+    cost: number[]
+    datavalues: {}
+    effect: number[][]
+    effectBurn: string[]
+    vars: {
+        link: string
+        coeff: number
+        key: string
+    }[]
+    costType: string
+    maxammo: string
+    range: number[]
+    rangeBurn: string
+    image: DDragonImageDTO
+    resource: string
+}
+export interface DDragonChampionSpellDTO extends DDragonSpellWrapper {
+    costBurn: string[]
+    leveltip: {
+        label: string[]
+        effect: string[]
+    }
+}
+export interface DDragonChampionDataDTO {
+    id: string
+    key: string
+    name: string
+    title: string
+    image: DDragonImageDTO
+    skins: {
+        id: string
+        num: number
+        name: string
+        chromas: boolean
+    }[]
+    lore: string
+    blurb: string
+    allytips: string[]
+    enemytips: string[]
+    tags: string[]
+    partype: string
+    info: DDragonChampionInfoDTO
+    stats: DDragonChampionStatsDTO
+    spells: DDragonChampionSpellDTO[]
+    passive: {
+        name: string
+        description: string
+        image: DDragonImageDTO
+    }
+    recommended: {
+        champion?: string
+        title?: string
+        map?: string
+        mode?: string
+        type: string
+        customTag: string
+        requiredPerk: string
+        sortrank: string
+        extensionPage: boolean
+        customPanel: string
+        customPanelCurrencyType?: string
+        customPanelBuffCurrencyName?: string
+        blocks: {
+            type: string
+            recMath: boolean
+            recSteps?: boolean
+            minSummonerLevel: number
+            maxSummonerLevel: number
+            showIfSummonerSpell: string
+            hideIfSummonerSpell: string
+            appendAfterSection?: string
+            visibleWithAllOf?: string[]
+            hiddenWithAnyOf?: string[]
+            items: {
+                id: string
+                count: number
+                hideCount: boolean
+            }[]
+        }[]
+    }[]
+}
+export interface DDragonItemWrapperDTO extends DDragonDataWrapper<DDragonItemDTO> {
+    basic: DDragonItemDTO
+    groups: {
+        id: string
+        MaxGroupOwnable: string
+    }[]
+    tree: {
+        header: string
+        tags: string[]
+    }[]
+}
+export interface DDragonItemDTO {
+    name: string
+    rune: {
+        isrune: boolean
+        tier: number
+        type: string
+    }
+    gold: {
+        base: number
+        total: number
+        sell: number
+        purchasable: boolean
+    }
+    group: string
+    description: string
+    colloq: string
+    plaintext: string
+    consumed: boolean
+    stacks: number
+    depth: number
+    consumeOnFull: boolean
+    from: string[]
+    into: string[]
+    image: DDragonImageDTO
+    specialRecipe: number
+    inStore: boolean
+    hideFromAll: boolean
+    requiredChampion: string
+    requiredAlly: string
+    stats: {
+        FlatHPPoolMod?: number
+        rFlatHPModPerLevel?: number
+        FlatMPPoolMod?: number
+        rFlatMPModPerLevel?: number
+        PercentHPPoolMod?: number
+        PercentMPPoolMod?: number
+        FlatHPRegenMod?: number
+        rFlatHPRegenModPerLevel?: number
+        PercentHPRegenMod?: number
+        FlatMPRegenMod?: number
+        rFlatMPRegenModPerLevel?: number
+        PercentMPRegenMod?: number
+        FlatArmorMod?: number
+        rFlatArmorModPerLevel?: number
+        PercentArmorMod?: number
+        rFlatArmorPenetrationMod?: number
+        rFlatArmorPenetrationModPerLevel?: number
+        rPercentArmorPenetrationMod?: number
+        rPercentArmorPenetrationModPerLevel?: number
+        FlatPhysicalDamageMod?: number
+        rFlatPhysicalDamageModPerLevel?: number
+        PercentPhysicalDamageMod?: number
+        FlatMagicDamageMod?: number
+        rFlatMagicDamageModPerLevel?: number
+        PercentMagicDamageMod?: number
+        FlatMovementSpeedMod?: number
+        rFlatMovementSpeedModPerLevel?: number
+        PercentMovementSpeedMod?: number
+        rPercentMovementSpeedModPerLevel?: number
+        FlatAttackSpeedMod?: number
+        PercentAttackSpeedMod?: number
+        rPercentAttackSpeedModPerLevel?: number
+        rFlatDodgeMod?: number
+        rFlatDodgeModPerLevel?: number
+        PercentDodgeMod?: number
+        FlatCritChanceMod?: number
+        rFlatCritChanceModPerLevel?: number
+        PercentCritChanceMod?: number
+        FlatCritDamageMod?: number
+        rFlatCritDamageModPerLevel?: number
+        PercentCritDamageMod?: number
+        FlatBlockMod?: number
+        PercentBlockMod?: number
+        FlatSpellBlockMod?: number
+        rFlatSpellBlockModPerLevel?: number
+        PercentSpellBlockMod?: number
+        FlatEXPBonus?: number
+        PercentEXPBonus?: number
+        rPercentCooldownMod?: number
+        rPercentCooldownModPerLevel?: number
+        rFlatTimeDeadMod?: number
+        rFlatTimeDeadModPerLevel?: number
+        rPercentTimeDeadMod?: number
+        rPercentTimeDeadModPerLevel?: number
+        rFlatGoldPer10Mod?: number
+        rFlatMagicPenetrationMod?: number
+        rFlatMagicPenetrationModPerLevel?: number
+        rPercentMagicPenetrationMod?: number
+        rPercentMagicPenetrationModPerLevel?: number
+        FlatEnergyRegenMod?: number
+        rFlatEnergyRegenModPerLevel?: number
+        FlatEnergyPoolMod?: number
+        rFlatEnergyModPerLevel?: number
+        PercentLifeStealMod?: number
+        PercentSpellVampMod?: number
+    }
+    tags: string[]
+    maps: {[key:string]: boolean}
+    effect?: {[key:string]: string}
+}
+export interface DDragonLanguageStringDTO extends DDragonDataWrapper<string> {
+    tree: {
+        searchKeyIgnore: string
+        searchKeyRemap: string
+    }
+
+}
+export interface DDragonMapDTO extends DDragonDataWrapper<DDragonMapDataDTO> { }
+export interface DDragonMapDataDTO {
+    MapName: string
+    MapId: string
+    image: DDragonImageDTO
+}
+export interface DDragonProfileIconDTO extends DDragonDataWrapper<DDragonImageDTO> { }
+export interface DDragonRealmsDTO {
+    n: {
+        item: string
+        rune: string
+        mastery: string
+        summoner: string
+        champion: string
+        profileicon: string
+        map: string
+        language: string
+        sticker: string
+    }
+    v: string
+    l: string
+    cdn: string
+    dd: string
+    lg: string
+    css: string
+    profileiconmax: number
+    store: null // This is just null on every server I checked. Always exists, but always null.
+}
+export interface DDragonSummonerSpellDTO extends DDragonDataWrapper<DDragonSummonerSpellDataDTO> { }
+export interface DDragonSummonerSpellDataDTO extends DDragonSpellWrapper {
+    costBurn: string
+    key: string
+    summonerLevel: number
+    modes: string[]
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -40,7 +40,9 @@ declare module 'kayn' {
 
         public DDragon: {
             Champion: {
-                get: (championName: string) => KaynDDragonRequest<dtos.DDragonChampionDTO>
+                get: (
+                    championName: string,
+                ) => KaynDDragonRequest<dtos.DDragonChampionDTO>
                 list: () => KaynDDragonRequest<dtos.DDragonChampionListDTO>
                 listFull: () => KaynDDragonRequest<dtos.DDragonChampionDTO>
                 getDataById: () => KaynDDragonRequest<dtos.DDragonChampionDTO>
@@ -66,7 +68,9 @@ declare module 'kayn' {
                 list: () => KaynDDragonRequest<dtos.DDragonProfileIconDTO>
             }
             Realm: {
-                list: (region: region) => KaynDDragonRequest<dtos.DDragonRealmsDTO>
+                list: (
+                    region: region,
+                ) => KaynDDragonRequest<dtos.DDragonRealmsDTO>
             }
             RunesReforged: {
                 list: () => KaynDDragonRequest<dtos.DDragonRunesReforgedDTO>

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -40,42 +40,42 @@ declare module 'kayn' {
 
         public DDragon: {
             Champion: {
-                get: (championName: string) => KaynDDragonRequest<any>
-                list: () => KaynDDragonRequest<any>
-                listFull: () => KaynDDragonRequest<any>
-                getDataById: () => KaynDDragonRequest<any>
-                getDataByIdWithParentAsId: () => KaynDDragonRequest<any>
-                listDataById: () => KaynDDragonRequest<any>
-                listDataByIdWithParentAsId: () => KaynDDragonRequest<any>
-                listFullDataById: () => KaynDDragonRequest<any>
-                listFullDataByIdWithParentAsId: () => KaynDDragonRequest<any>
+                get: (championName: string) => KaynDDragonRequest<dtos.DDragonChampionDTO>
+                list: () => KaynDDragonRequest<dtos.DDragonChampionListDTO>
+                listFull: () => KaynDDragonRequest<dtos.DDragonChampionDTO>
+                getDataById: () => KaynDDragonRequest<dtos.DDragonChampionDTO>
+                getDataByIdWithParentAsId: () => KaynDDragonRequest<dtos.DDragonChampionDTO>
+                listDataById: () => KaynDDragonRequest<dtos.DDragonChampionListDTO>
+                listDataByIdWithParentAsId: () => KaynDDragonRequest<dtos.DDragonChampionListDTO>
+                listFullDataById: () => KaynDDragonRequest<dtos.DDragonChampionDTO>
+                listFullDataByIdWithParentAsId: () => KaynDDragonRequest<dtos.DDragonChampionDTO>
             }
             Item: {
-                list: () => KaynDDragonRequest<any>
+                list: () => KaynDDragonRequest<dtos.DDragonItemWrapperDTO>
             }
             Language: {
-                list: () => KaynDDragonRequest<any>
+                list: () => KaynDDragonRequest<string[]>
             }
             LanguageString: {
-                list: () => KaynDDragonRequest<any>
+                list: () => KaynDDragonRequest<dtos.DDragonLanguageStringDTO>
             }
             Map: {
-                list: () => KaynDDragonRequest<any>
+                list: () => KaynDDragonRequest<dtos.DDragonMapDTO>
             }
             ProfileIcon: {
-                list: () => KaynDDragonRequest<any>
+                list: () => KaynDDragonRequest<dtos.DDragonProfileIconDTO>
             }
             Realm: {
-                list: (region: region) => KaynDDragonRequest<any>
+                list: (region: region) => KaynDDragonRequest<dtos.DDragonRealmsDTO>
             }
             RunesReforged: {
-                list: () => KaynDDragonRequest<any>
+                list: () => KaynDDragonRequest<dtos.DDragonRunesReforgedDTO>
             }
             SummonerSpell: {
-                list: () => KaynDDragonRequest<any>
+                list: () => KaynDDragonRequest<dtos.DDragonSummonerSpellDataDTO>
             }
             Version: {
-                list: () => KaynDDragonRequest<any>
+                list: () => KaynDDragonRequest<string[]>
             }
         }
 
@@ -111,17 +111,17 @@ declare module 'kayn' {
         }
 
         public Match: {
-            get: (matchID: number) => KaynRequest<dtos.MatchV4MatchDto>
+            get: (matchID: number) => KaynRequest<dtos.MatchV4MatchDTO>
             timeline: (
                 matchID: number,
-            ) => KaynRequest<dtos.MatchV4MatchTimelineDto>
+            ) => KaynRequest<dtos.MatchV4MatchTimelineDTO>
 
             Tournament: {
                 listMatchIDs: (tournamentCode: string) => KaynRequest<number[]>
                 get: (
                     matchID: number,
                     tournamentCode: string,
-                ) => KaynRequest<dtos.MatchV4MatchDto>
+                ) => KaynRequest<dtos.MatchV4MatchDTO>
             }
         }
 
@@ -129,13 +129,13 @@ declare module 'kayn' {
             by: {
                 accountID: (
                     accountID: string,
-                ) => KaynRequest<dtos.MatchV4MatchlistDto>
+                ) => KaynRequest<dtos.MatchV4MatchlistDTO>
             }
             Recent: {
                 by: {
                     accountID: (
                         accountID: string,
-                    ) => KaynRequest<dtos.MatchV4MatchlistDto>
+                    ) => KaynRequest<dtos.MatchV4MatchlistDTO>
                 }
             }
         }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -76,7 +76,7 @@ declare module 'kayn' {
                 list: () => KaynDDragonRequest<dtos.DDragonRunesReforgedDTO>
             }
             SummonerSpell: {
-                list: () => KaynDDragonRequest<dtos.DDragonSummonerSpellDataDTO>
+                list: () => KaynDDragonRequest<dtos.DDragonSummonerSpellDTO>
             }
             Version: {
                 list: () => KaynDDragonRequest<string[]>


### PR DESCRIPTION
I don't agree with the linter on how it wants to format some of the lines in the champion section. It makes it harder to read. I'm not a lint guru so I'm not sure how to prevent it from doing that, so I just manually removed it. That's not really useful going forward since you would have to do that every time the linter is run. Here is what it wanted to do:

```
getDataByIdWithParentAsId: () => KaynDDragonRequest<
    dtos.DDragonChampionDTO
>
listDataById: () => KaynDDragonRequest<
    dtos.DDragonChampionListDTO
>
listDataByIdWithParentAsId: () => KaynDDragonRequest<
    dtos.DDragonChampionListDTO
>
listFullDataById: () => KaynDDragonRequest<
    dtos.DDragonChampionDTO
>
listFullDataByIdWithParentAsId: () => KaynDDragonRequest<
    dtos.DDragonChampionDTO
>
```