### PR TITLE
add config option for custom API URL prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ yarn add kayn
 const { Kayn, REGIONS } = require('kayn')
 const kayn = Kayn('RGAPI-my-api-key')(/*{
     region: REGIONS.NORTH_AMERICA,
+    apiURLPrefix: 'https://%s.api.riotgames.com',
     locale: 'en_US',
     debugOptions: {
         isEnabled: true,

--- a/lib/KaynConfig.js
+++ b/lib/KaynConfig.js
@@ -5,6 +5,7 @@ import METHOD_NAMES from 'Enums/method-names'
 export const DEFAULT_KAYN_CONFIG = {
     region: 'na',
     locale: 'en_US',
+    apiURLPrefix: 'https://%s.api.riotgames.com',
     debugOptions: {
         isEnabled: true,
         showKey: false,
@@ -43,6 +44,7 @@ Object.keys(METHOD_NAMES).forEach(groupName => {
 export const KAYN_CONFIG_STRUCT = struct({
     region: 'string',
     locale: 'string',
+    apiURLPrefix: 'string',
     debugOptions: {
         isEnabled: 'boolean',
         showKey: 'boolean',

--- a/lib/RequestClient/Request.js
+++ b/lib/RequestClient/Request.js
@@ -11,6 +11,7 @@ function Request(
     body, // POST/PUT
     isTournament = false,
     version = 3,
+    apiURLPrefix = config.apiURLPrefix,
 ) {
     this.payload = {
         method: httpMethodType || 'GET',
@@ -21,6 +22,7 @@ function Request(
         body,
         isTournament,
         version,
+        apiURLPrefix,
     }
     if (this.payload.method === 'GET') delete this.payload.body
     this.config = config
@@ -76,6 +78,7 @@ Request.prototype.callback = function(cb) {
         body,
         isTournament,
         version,
+        apiURLPrefix,
     } = this.payload
     const url = URLHelper.getURLWithQuery(
         RegionHelper.asPlatformID(region),
@@ -84,6 +87,7 @@ Request.prototype.callback = function(cb) {
         query,
         isTournament,
         version,
+        apiURLPrefix,
     )
     const { key: token } = this.config
 

--- a/lib/Utils/URLHelper.js
+++ b/lib/Utils/URLHelper.js
@@ -1,16 +1,30 @@
 import DateTimeHelper from './DateTimeHelper'
 
-const API_HOST = 'api.riotgames.com'
+const createRequestURL = (
+    platformID,
+    serviceName,
+    endpoint,
+    version,
+    apiURLPrefix,
+) => {
+    const prefix = apiURLPrefix.replace(/%s/, platformID)
+    return `${prefix}/lol/${serviceName}/v${version}/${endpoint}`
+}
 
-const createRequestURL = (platformID, serviceName, endpoint, version) =>
-    `https://${platformID}.${API_HOST}/lol/${serviceName}/v${version}/${endpoint}`
-
-const getURLWithKey = (platformID, serviceName, endpoint, key, version) => {
+const getURLWithKey = (
+    platformID,
+    serviceName,
+    endpoint,
+    key,
+    version,
+    apiURLPrefix,
+) => {
     const requestURL = createRequestURL(
         platformID,
         serviceName,
         endpoint,
         version,
+        apiURLPrefix,
     )
     return requestURL + getAPIKey(requestURL, key)
 }
@@ -55,12 +69,14 @@ const getURLWithQuery = (
     queryArray,
     isTournament,
     version,
+    apiURLPrefix,
 ) =>
     createRequestURL(
         isTournament ? 'americas' : region,
         serviceName,
         endpoint,
         version,
+        apiURLPrefix,
     ) + getQueryParamString(queryArray)
 
 export default {

--- a/test/unit/Request.spec.js
+++ b/test/unit/Request.spec.js
@@ -80,6 +80,35 @@ describe('Request', function() {
         })
     })
 
+    it('should initialize correctly #4', function() {
+        const request = new Request(
+            defaultConfig,
+            'summoner',
+            'by-name/chaullenger',
+            'abc',
+            'PUT',
+            null,
+            { hello: 'world' },
+            true,
+            3,
+            'http://localhost',
+        )
+        const { config, methodName, payload } = request
+        expect(config).to.deep.equal(defaultConfig)
+        expect(methodName).to.deep.equal('abc')
+        expect(payload).to.deep.equal({
+            method: 'PUT',
+            serviceName: 'summoner',
+            endpoint: 'by-name/chaullenger',
+            query: [],
+            region: '',
+            body: { hello: 'world' },
+            isTournament: true,
+            version: 3,
+            apiURLPrefix: 'http://localhost',
+        })
+    })
+
     it('should add query parameters correctly', function() {
         const request = new Request(
             defaultConfig,

--- a/test/unit/utils/URLHelper.spec.js
+++ b/test/unit/utils/URLHelper.spec.js
@@ -41,4 +41,44 @@ describe('URLHelper', function() {
             expect(actual).to.equal('?name=T%C3%A9st&rank=%C3%B3h%20no')
         })
     })
+
+    describe('createRequestURL', function() {
+        it('should create a request URL', function() {
+            const url = URLHelper.createRequestURL(
+                'na1',
+                'tournament',
+                'endpoint',
+                '1',
+            )
+            expect(actual).to.equal(
+                'https://na1.api.riotgames.com/lol/tournament/v4/endpoint',
+            )
+        })
+
+        it('should create a request URL with a custom API URL prefix', function() {
+            const url = URLHelper.createRequestURL(
+                'na1',
+                'tournament',
+                'endpoint',
+                '1',
+                'http://%s.localhost',
+            )
+            expect(actual).to.equal(
+                'http://na1.localhost/lol/tournament/v4/endpoint',
+            )
+        })
+
+        it('should create a request URL with a custom API URL prefix with no platform ID', function() {
+            const url = URLHelper.createRequestURL(
+                'na1',
+                'tournament',
+                'endpoint',
+                '1',
+                'http://localhost',
+            )
+            expect(actual).to.equal(
+                'http://localhost/lol/tournament/v4/endpoint',
+            )
+        })
+    })
 })

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -206,6 +206,7 @@ type methodName = string
 type endpoint = string
 interface KaynConfig {
     region?: region
+    apiURLPrefix?: string
     debugOptions?: {
         isEnabled?: boolean
         showKey?: boolean


### PR DESCRIPTION
Implements #76

Switches from a hardcoded API host to a configurable API URL prefix that defaults to `https://%s.api.riotgames.com`.