### PR TITLE
Updated types for summonerID

### DIFF
--- a/lib/Endpoints/ChampionMasteryEndpointV4.js
+++ b/lib/Endpoints/ChampionMasteryEndpointV4.js
@@ -71,7 +71,7 @@ class ChampionMasteryEndpointV4 extends Endpoint {
      *
      * Implements GET `/lol/champion-mastery/v4/scores/by-summoner/{encryptedSummonerId}`.
      *
-     * @param {number} summonerID - The ID of the summoner.
+     * @param {string} summonerID - The ID of the summoner.
      */
     totalScore(summonerID) {
         return new Request(

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -9,8 +9,8 @@ declare module 'kayn' {
 
         public ChampionMastery: {
             get: (summonerID: string) => (championID: number) => KaynRequest<dtos.ChampionMasteryV4ChampionMasteryDTO>
-            list: (summonerID: number) => KaynRequest<dtos.ChampionMasteryV4ChampionMasteryDTO[]>
-            totalScore: (summonerID: number) => KaynRequest<number>
+            list: (summonerID: string) => KaynRequest<dtos.ChampionMasteryV4ChampionMasteryDTO[]>
+            totalScore: (summonerID: string) => KaynRequest<number>
         }
 
         public Champion: {


### PR DESCRIPTION
Typescript compiler complains when I use ChampionMastery endpoint due to type error.

Updated a couple of occurrences where summonerId type was number rather than string.