### PR TITLE
FixedTyping for League Entries endpoint

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -76,7 +76,9 @@ declare module 'kayn' {
             }
 
             Entries: {
-                bySummonerID: (encryptedSummonerID: string) => KaynRequest<dtos.LeagueV4LeagueEntryDTO[]>
+                by: {
+                    summonerID: (encryptedSummonerID: string) => KaynRequest<dtos.LeagueV4LeagueEntryDTO[]>
+                },
                 list: (queue: queueName, tier: string, division: string) => KaynRequest<dtos.LeagueV4LeagueEntryDTO[]>
             }
         }


### PR DESCRIPTION
In the typing the Entries endpoint is called via kayn.League.Entries.bySummonerId(id), however in the LeagueEntriesEndpointV4  it is defined as Entries.by.summonerID(id).
This leads to: 
TypeError: kayn.League.Entries.bySummonerID is not a function