### PR TITLE
73 - Return current version when endpoint does not have its own version

### DIFF
--- a/lib/RequestClient/DDragonRequest.js
+++ b/lib/RequestClient/DDragonRequest.js
@@ -123,13 +123,14 @@ class DDragonRequest {
         // Otherwise, we call the endpoint manually, cache it, and then proceed.
         if (type === DDragonRequestTypes.CDN.DATA && !version) {
             const getVersionFromMap = (endpoint, versions) => {
-                if (endpoint.includes('item')) return versions.item
-                if (endpoint.includes('summoner')) return versions.summoner
-                if (endpoint.includes('champion')) return versions.champion
+                if (endpoint.includes('item')) return versions.n.item
+                if (endpoint.includes('summoner')) return versions.n.summoner
+                if (endpoint.includes('champion')) return versions.n.champion
                 if (endpoint.includes('profileicon'))
-                    return versions.profileicon
-                if (endpoint.includes('map')) return versions.map
-                if (endpoint.includes('language')) return versions.language
+                    return versions.n.profileicon
+                if (endpoint.includes('map')) return versions.n.map
+                if (endpoint.includes('language')) return versions.n.language
+                return versions.v;
             }
             const executeWithVersion = (endpoint, versions) => {
                 const version = getVersionFromMap(endpoint, versions)
@@ -155,15 +156,14 @@ class DDragonRequest {
                     },
                     function(err, data) {
                         if (data) {
-                            executeWithVersion(endpoint, data.n)
+                            executeWithVersion(endpoint, data)
                         } else {
                             const url = ddragonRequestTypeToUrl(
                                 DDragonRequestTypes.REALMS,
                                 realmArg,
                             )
                             self.execute(url, true, function(err, data) {
-                                const { n: versions } = data
-                                executeWithVersion(endpoint, versions)
+                                executeWithVersion(endpoint, data)
                             })
                         }
                     },
@@ -176,8 +176,7 @@ class DDragonRequest {
                     realmArg,
                 )
                 self.execute(url, true, function(err, data) {
-                    const { n: versions } = data
-                    executeWithVersion(endpoint, versions)
+                    executeWithVersion(endpoint, data)
                 })
                 return
             }


### PR DESCRIPTION
This PR resolves issue #73 .

This approach was taken because of the below image which explains that the version property ("v") contains the version of all currently supported endpoints and that the specific endpoint for runesReforged is not necessary because of this.

![63632162-59b9a780-c5e6-11e9-9cb7-e6bb9ffe8371](https://user-images.githubusercontent.com/4654099/81757537-347b0b00-948d-11ea-80f2-c9a3cdaf0bed.png)
