### PR TITLE
Update typings for League endpoint

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -76,7 +76,9 @@ declare module 'kayn' {
             }
 
             Entries: {
-                bySummonerID: (encryptedSummonerID: string) => KaynRequest<dtos.LeagueV4LeagueEntryDTO[]>
+                by: {
+                    summonerID: (encryptedSummonerID: string) => KaynRequest<dtos.LeagueV4LeagueEntryDTO[]>
+                }
                 list: (queue: queueName, tier: string, division: string) => KaynRequest<dtos.LeagueV4LeagueEntryDTO[]>
             }
         }


### PR DESCRIPTION
Renaming the method `bySummonerId` (which does not exist), with the correct signature